### PR TITLE
Set BlogPage author on_delete. Remove orphan endblock from template.

### DIFF
--- a/wagtail_blog/models.py
+++ b/wagtail_blog/models.py
@@ -24,7 +24,11 @@ class BlogPageTag(TaggedItemBase):
 class BlogPage(Page):
     content = RichTextField()
     author = models.ForeignKey(
-        settings.WAGTAIL_BLOG_AUTHOR_PAGE, blank=True, null=True)
+        settings.WAGTAIL_BLOG_AUTHOR_PAGE,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL
+    )
 
     image = models.ForeignKey(
         'wagtailimages.Image',

--- a/wagtail_blog/templates/wagtail_blog/blog_index_page.html
+++ b/wagtail_blog/templates/wagtail_blog/blog_index_page.html
@@ -30,5 +30,3 @@
 
     {% include 'wagtail_blog/fragments/paginator.html' %}
 </main>
-
-{% endblock %}


### PR DESCRIPTION
Adding an on_delete value to avoid manage.py migrate warning: wagtail_blog.BlogPage.author: (wagtailcore.W001) Field hasn't specified on_delete action. Assuming SET_NULL is sensible because you allow null authors already.
